### PR TITLE
Allow setting group value in token via environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ services:
     # - 'VERIFY_ACCESS_TOKEN_HASH=false          # <- explicitly disable access token hash verification (OPTIONAL),
                                                  #    default: true
     # - 'SKIP_PREJOIN_SCREEN=false'              # <- skips the jitsi prejoin screen after login (default: true)
+    # - 'GROUP=example'                          # <- Value for the 'group' field in the token
+                                                 #    default: ''
     ports:
       - '3000:3000'
 

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -29,6 +29,9 @@ pub(crate) struct Cfg {
   pub(crate) verify_access_token_hash: Option<bool>,
   #[serde(default)]
   pub(crate) skip_prejoin_screen: Option<bool>,
+  #[serde(default)]
+  pub(crate) group: String,
+
 }
 
 fn default_listen_addr() -> SocketAddr {

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -154,6 +154,7 @@ async fn callback(
     config.jitsi_sub,
     "*".to_string(),
     config.jitsi_secret,
+    config.group,
   )
   .map_err(|err| {
     error!("Unable to create jwt: {}", err);
@@ -316,11 +317,12 @@ fn create_jitsi_jwt(
   sub: String,
   room: String,
   secret: String,
+  group: String,
 ) -> anyhow::Result<String> {
   let iat = OffsetDateTime::now_utc();
   let exp = iat + Duration::days(1);
 
-  let context = JitsiContext { user, group: None };
+  let context = JitsiContext { user, group: Some(group) };
   let claims = JitsiClaims {
     context,
     aud,


### PR DESCRIPTION
This fixes #261

`group` by default is now the empty string and is configurable with an environment variable.
Thus mod_presence_identity will no longer crash